### PR TITLE
boto now optional

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -1166,8 +1166,11 @@ class DB(object):
         """
         if self.dbtype!="redshift":
             raise Exception("Sorry, feature only available for redshift.")
-        from boto.s3.connection import S3Connection
-        from boto.s3.key import Key
+        try:
+            from boto.s3.connection import S3Connection
+            from boto.s3.key import Key
+        except ImportError:
+            raise Exception("Couldn't find boto library. Please ensure it is installed")
 
         if AWS_ACCESS_KEY is None:
             AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY')

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@ from setuptools import find_packages
 
 required = [
     "prettytable==0.7.2",
-    "pandas==0.15.0",
-    "boto==2.30.0"
+    "pandas==0.15.0"
 ]
 
 setup(


### PR DESCRIPTION
Since boto is only being imported for one function (uploading to redshift), there are now just try/except clauses around the import.

Requested by: https://github.com/yhat/db.py/issues/6
