### PR TITLE
Add DemoDB() initialization in setUp()

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -1438,11 +1438,11 @@ def remove_profile(name, s3=False):
         raise Exception("Could not remove profile {0}! Excpetion: {1}".format(name, e))
 
 
-def DemoDB():
+def DemoDB(keys_per_column=None):
     """
     Provides an instance of DB that hooks up to the Chinook DB
     See http://chinookdatabase.codeplex.com/ for more info.
     """
     _ROOT = os.path.abspath(os.path.dirname(__file__))
     chinook = os.path.join(_ROOT, 'data', "chinook.sqlite")
-    return DB(filename=chinook, dbtype="sqlite")
+    return DB(filename=chinook, dbtype="sqlite", keys_per_column=keys_per_column)

--- a/db/tests/tests.py
+++ b/db/tests/tests.py
@@ -3,12 +3,9 @@ from db import DemoDB, DB, list_profiles, remove_profile
 import unittest
 
 
-#db = DemoDB()
-
 class PandaSQLTest(unittest.TestCase):
 
     def setUp(self):
-        #pass
         self.db = DemoDB()
 
     def test_query_rowsum(self):


### PR DESCRIPTION
I added DemoDB() initialization in setUp() for tests and the tests were passing (except for one). But there are two issues/observations:

1) setUp() method is run before every test method. So Refresh schema and Indexing schema happens at every test method. This could be a good thing. But if you think it is inefficient, there may be a way such that the DemoDB initialization happens only once before all the tests are run. If you want that, I can modify it. 

2) The test test_table_keys_per_column fails and I get the following error:
# 
## ERROR: test_table_keys_per_column (tests.PandaSQLTest)

Traceback (most recent call last):
  File "/Users/ue/Desktop/Projects/db.py/db/tests/tests.py", line 73, in test_table_keys_per_column
    short_db = DemoDB(keys_per_column=1)
TypeError: DemoDB() takes no arguments (1 given)

---

Ran 14 tests in 0.127s

FAILED (errors=1)

Did you plan to add default parameter to DemoDB?
