### PR TITLE
Add support for specifying bucket locations in to_redshift

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -1307,10 +1307,6 @@ class DB(object):
             # if boto is present, set the bucket_location to default.
             # we can't do this in the function definition because we're 
             # lazily importing boto only if necessary here.
-
-            print "bucket location: " + str(bucket_location)
-            print type(bucket_location)
-
             if bucket_location is None:
                 bucket_location = Location.DEFAULT
 


### PR DESCRIPTION
In order to use the s3 copy function in redshift, the s3 bucket must be in the same region as the redshift cluster running the copy command. As written, `to_redshift` would only upload to the default region which for my redshift cluster was not appropriate. Boto supports region specification, this PR lets you specify the region in the to_redshift call in a boto standard way. 
