### PR TITLE
Enable autocommit by default for mysql

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -791,6 +791,7 @@ class DB(object):
                         arg = "host"
                     creds[arg] = value
             self.con = mysql_connect(**creds)
+            self.con.autocommit(True)
             self.cur = self.con.cursor()
         elif self.dbtype=="mssql":
             if not HAS_ODBC and not HAS_PYMSSQL:


### PR DESCRIPTION
This disables unintuitive behavior whereby `SELECT`s are cached over the lifetime of a session. (Presumably the lack of autocommit would also break anything that modified the database as well but I have not tested that.)
