### PR TITLE
Fixing query_from_file call method in db/db.py

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -1205,7 +1205,7 @@ class DB(object):
             q = self._assign_limit(q, limit)
         return pd.io.sql.read_sql(q, self.con)
 
-    def query_from_file(self, filename, data, union=True, limit=None):
+    def query_from_file(self, filename, data=None, union=True, limit=None):
         """
         Query your database from a file.
 
@@ -1264,9 +1264,12 @@ class DB(object):
         8                               Snowballed       0.99
         9                               Evil Walks       0.99
         """
-        q = open(filename).read()
-        if data:
-            q = self._apply_handlebars(q, data, union)
+
+        with open(filename) as fp:
+            q = fp.read()
+            if data:
+                q = self._apply_handlebars(q, data, union)
+
         return self.query(q, limit)
 
     def _create_sqlite_metatable(self):


### PR DESCRIPTION
The argument "data" in method definition is defined as required,
but the docstring says it is optinonal. Refactored file read call at
the end of method. The best pratice is to close file just after use.