### PR TITLE
space better than tabs (pip install error)

### DIFF
--- a/db/tests/tests.py
+++ b/db/tests/tests.py
@@ -55,8 +55,8 @@ class PandaSQLTest(unittest.TestCase):
         self.assertEqual(len(df), 10)
 
     def test_table_uniqe(self):
-	df = self.db.tables.Track.unique("GenreId", "MediaTypeId")
-	self.assertEqual(len(df), 38)
+        df = self.db.tables.Track.unique("GenreId", "MediaTypeId")
+        self.assertEqual(len(df), 38)
 
     def test_column_head(self):
         col = self.db.tables.Track.TrackId.head()


### PR DESCRIPTION
````
      Successfully uninstalled db.py-0.4.1
  Running setup.py install for db.py
    Sorry: TabError: inconsistent use of tabs and spaces in indentation (tests.p
y, line 58)
````