### PR TITLE
Lazy load database schema

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -273,8 +273,8 @@ class Table(object):
         self._columns = cols
         for col in cols:
             attr = col.name
-            if attr in ("name", "con"):
-                attr = "_" + col.name
+            if attr in ("name", "con", "count"):
+                attr = self.name + "_" + col.name
             setattr(self, attr, col)
 
         self._cur.execute(self._query_templates['system']['foreign_keys_for_table'].format(table=self.name))

--- a/db/db.py
+++ b/db/db.py
@@ -592,6 +592,9 @@ class TableSet(object):
     def _repr_html_(self):
         return self._tablify().get_html_string()
 
+    def __len__(self):
+        return len(self.tables)
+
 class ColumnSet(object):
     """
     Set of Columns. Used for displaying search results in terminal/ipython
@@ -849,9 +852,16 @@ class DB(object):
                                            database=self.dbname)
                 self.cur = self.con.cursor()
 
-        self.tables = TableSet([])
-        self.refresh_schema(exclude_system_tables)
+        self._tables = TableSet([])
+        self._exclude_system_tables = exclude_system_tables
         self.handlebars = pybars.Compiler()
+
+    @property
+    def tables(self):
+        """A lazy loaded reference to the table metadata for the DB."""
+        if len(self._tables) == 0:
+            self.refresh_schema(self._exclude_system_tables)
+        return self._tables
 
     def __str__(self):
         return "DB[{dbtype}][{hostname}]:{port} > {user}@{dbname}".format(
@@ -1354,7 +1364,7 @@ class DB(object):
                 tables[table_name] = []
             tables[table_name].append(Column(self.con, self._query_templates, table_name, column_name, data_type, self.keys_per_column))
 
-        self.tables = TableSet([Table(self.con, self._query_templates, t, tables[t], keys_per_column=self.keys_per_column) for t in sorted(tables.keys())])
+        self._tables = TableSet([Table(self.con, self._query_templates, t, tables[t], keys_per_column=self.keys_per_column) for t in sorted(tables.keys())])
         sys.stderr.write("done!\n")
 
     def _try_command(self, cmd):

--- a/db/db.py
+++ b/db/db.py
@@ -1347,9 +1347,7 @@ class DB(object):
         else:
             q = self._query_templates['system']['schema_with_system']
 
-        tables = set()
         self.cur.execute(q)
-        cols = []
         tables = {}
         for (table_name, column_name, data_type)in self.cur:
             if table_name not in tables:


### PR DESCRIPTION
This commit makes it possible to use DB's query functionality without needing to load the schema information. This helps a lot for databases with a large number of tables that you might interact with, but you also create reusable queries for. If you want to have a one time call to a query, the delay causes by loading the schema dwarfs the time it takes to retrieve the data.

This works by adding table as a property of the DB class. Any time table is called, it checks the private _table property's length. If the length is equal to 0, only then will it call the method to refresh the schema. Otherwise, it just returns _table once it is loaded. This approach limits the affect on the rest of the code.