### PR TITLE
Add capability to save and load cache of metadata

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -1674,7 +1674,12 @@ def list_profiles():
     user = os.path.expanduser("~")
     for f in os.listdir(user):
         if f.startswith(".db.py_"):
-            profile = load_from_json(f)
+            profile = load_from_json(os.path.join(user, f))
+            tables = profile.pop('tables', None)
+            if tables:
+                profile['metadata'] = True
+            else:
+                profile['metadata'] = False
             profiles[f[7:]] = profile
     return profiles
 

--- a/db/db.py
+++ b/db/db.py
@@ -158,7 +158,7 @@ class Column(object):
         Name: City, dtype: object
         """
         q = self._query_templates['column']['head'].format(column=self.name, table=self.table, n=n)
-        return pd.io.sql.read_sql(q, self._con)[self.name]
+        return pd.read_sql(q, self._con)[self.name]
 
     def all(self):
         """
@@ -425,7 +425,7 @@ class Table(object):
         0       0.99
         """
         q = self._query_templates['table']['head'].format(table=self.name, n=n)
-        return pd.io.sql.read_sql(q, self._con)
+        return pd.read_sql(q, self._con)
 
     def all(self):
         """

--- a/db/db.py
+++ b/db/db.py
@@ -974,7 +974,7 @@ class DB(object):
         f = _profile_path(DBPY_PROFILE_ID, profile)
         if f:
             prof = load_from_json(f)
-            return prof['tables']
+            return prof.get('tables', None)
 
     def save_metadata(self, profile="default"):
         """Save the database credentials, plus the database properties to your db.py profile."""
@@ -1464,7 +1464,7 @@ class DB(object):
         tables = {}
 
         # pull out column metadata for all tables as list of tuples if told to use cached metadata
-        if use_cache:
+        if use_cache and self._metadata_cache:
             sys.stderr.write("Loading cached metadata. Please wait...")
             col_meta = []
             for table in self._metadata_cache:

--- a/db/db.py
+++ b/db/db.py
@@ -898,7 +898,7 @@ class DB(object):
         profile: str
             (optional) identifier/name for your database (i.e. "dw", "prod")
         """
-        f = self._profile_path(profile)
+        f = _profile_path(DBPY_PROFILE_ID, profile)
         if os.path.exists(f):
             raw_creds = open(f, 'rb').read()
             raw_creds = base64.decodestring(raw_creds).decode('utf-8')
@@ -1594,6 +1594,7 @@ def remove_profile(name, s3=False):
     except Exception as e:
         raise Exception("Could not remove profile {0}! Excpetion: {1}".format(name, e))
 
+
 def dump_to_json(file_path, data):
     with open(file_path, 'wb') as f:
         json_data = json.dumps(data)
@@ -1602,10 +1603,12 @@ def dump_to_json(file_path, data):
         except:
             f.write(base64.encodestring(bytes(json_data, 'utf-8')))
 
+
 def _profile_path(profile_id, profile):
     """Create full path to given provide for the current user."""
     user = os.path.expanduser("~")
     return os.path.join(user, profile_id + profile)
+
 
 def DemoDB(keys_per_column=None):
     """

--- a/db/db.py
+++ b/db/db.py
@@ -1638,6 +1638,14 @@ class DB(object):
         """Nested loading of database metadata."""
         pass
 
+
+def load_from_json(file_path):
+    """Load the stored data from json, and return as a dict."""
+    if os.path.exists(file_path):
+        raw_data = open(file_path, 'rb').read()
+        return json.loads(base64.decodestring(raw_data).decode('utf-8'))
+
+
 def list_profiles():
     """
     Lists all of the database profiles available
@@ -1666,8 +1674,7 @@ def list_profiles():
     user = os.path.expanduser("~")
     for f in os.listdir(user):
         if f.startswith(".db.py_"):
-            profilePath = os.path.join(user, f)
-            profile = json.loads(base64.decodestring(open(profilePath,'rb').read()).decode('utf-8'))
+            profile = load_from_json(f)
             profiles[f[7:]] = profile
     return profiles
 
@@ -1699,13 +1706,6 @@ def dump_to_json(file_path, data):
             f.write(base64.encodestring(json_data))
         except:
             f.write(base64.encodestring(bytes(json_data, 'utf-8')))
-
-
-def load_from_json(file_path):
-    if os.path.exists(file_path):
-        raw_creds = open(file_path, 'rb').read()
-        raw_creds = base64.decodestring(raw_creds).decode('utf-8')
-        return json.loads(raw_creds)
 
 
 def _profile_path(profile_id, profile):

--- a/db/db.py
+++ b/db/db.py
@@ -257,6 +257,7 @@ class Column(object):
         return pd.io.sql.read_sql(q, self._con)[self.name]
 
     def to_dict(self):
+        """Serialize representation of the column for local caching."""
         return {'table': self.table, 'name': self.name, 'type': self.type}
 
 class Table(object):
@@ -561,6 +562,10 @@ class Table(object):
         """Return total of rows from table."""
         return len(self.all())
 
+    def to_dict(self):
+        """Serialize representation of the table for local caching."""
+        return {'name': self.name, 'columns': [col.to_dict() for col in self._columns],
+                'foreign_keys': self.foreign_keys.to_dict(), 'ref_keys': self.ref_keys.to_dict()}
 
 class TableSet(object):
     """
@@ -595,6 +600,10 @@ class TableSet(object):
     def _repr_html_(self):
         return self._tablify().get_html_string()
 
+    def to_dict(self):
+        """Serialize representation of the tableset for local caching."""
+        return {'tables': [table.to_dict() for table in self.tables]}
+
 class ColumnSet(object):
     """
     Set of Columns. Used for displaying search results in terminal/ipython
@@ -621,6 +630,10 @@ class ColumnSet(object):
 
     def _repr_html_(self):
         return self._tablify().get_html_string()
+
+    def to_dict(self):
+        """Serialize representation of the tableset for local caching."""
+        return {'columns': [col.to_dict() for col in self.columns]}
 
 class S3(object):
     """

--- a/db/db.py
+++ b/db/db.py
@@ -185,7 +185,7 @@ class Column(object):
         59
         """
         q = self._query_templates['column']['all'].format(column=self.name, table=self.table)
-        return pd.io.sql.read_sql(q, self._con)[self.name]
+        return pd.read_sql(q, self._con)[self.name]
 
     def unique(self):
         """
@@ -216,7 +216,7 @@ class Column(object):
         59
         """
         q = self._query_templates['column']['unique'].format(column=self.name, table=self.table)
-        return pd.io.sql.read_sql(q, self._con)[self.name]
+        return pd.read_sql(q, self._con)[self.name]
 
     def sample(self, n=10):
         """
@@ -257,7 +257,7 @@ class Column(object):
         10
         """
         q = self._query_templates['column']['sample'].format(column=self.name, table=self.table, n=n)
-        return pd.io.sql.read_sql(q, self._con)[self.name]
+        return pd.read_sql(q, self._con)[self.name]
 
     def to_dict(self):
         """Serialize representation of the column for local caching."""
@@ -371,7 +371,7 @@ class Table(object):
         >>> df = db.tables.Track.select("Name", "Composer")
         """
         q = self._query_templates['table']['select'].format(columns=", ".join(args), table=self.name)
-        return pd.io.sql.read_sql(q, self._con)
+        return pd.read_sql(q, self._con)
 
     def head(self, n=6):
         """
@@ -454,7 +454,7 @@ class Table(object):
         """
 
         q = self._query_templates['table']['all'].format(table=self.name)
-        return pd.io.sql.read_sql(q, self._con)
+        return pd.read_sql(q, self._con)
 
     def unique(self, *args):
         """
@@ -511,7 +511,7 @@ class Table(object):
         else:
             columns = ", ".join(args)
         q = self._query_templates['table']['unique'].format(columns=columns, table=self.name)
-        return pd.io.sql.read_sql(q, self._con)
+        return pd.read_sql(q, self._con)
 
     def sample(self, n=10):
         """
@@ -1642,10 +1642,6 @@ class DB(object):
         db_dict = self.credentials
         db_dict.update(self.tables.to_dict())
         return db_dict
-
-    def from_dict(self):
-        """Nested loading of database metadata."""
-        pass
 
 
 def load_from_json(file_path):

--- a/db/db.py
+++ b/db/db.py
@@ -1347,9 +1347,7 @@ class DB(object):
         else:
             q = self._query_templates['system']['schema_with_system']
 
-        tables = set()
         self.cur.execute(q)
-        cols = []
         tables = {}
         for (table_name, column_name, data_type)in self.cur:
             if table_name not in tables:

--- a/db/db.py
+++ b/db/db.py
@@ -256,6 +256,9 @@ class Column(object):
         q = self._query_templates['column']['sample'].format(column=self.name, table=self.table, n=n)
         return pd.io.sql.read_sql(q, self._con)[self.name]
 
+    def to_dict(self):
+        return {'table': self.table, 'name': self.name, 'type': self.type}
+
 class Table(object):
     """
     A Table is an in-memory reference to a table in a database. You can use it to get more info

--- a/db/queries/mysql.py
+++ b/db/queries/mysql.py
@@ -14,8 +14,8 @@ queries = {
     },
     "system": {
         "schema_no_system": """
-                select
-                    table_name
+                select table_schema
+                    , table_name
                     , column_name
                     , data_type
                 from
@@ -24,16 +24,16 @@ queries = {
                     table_schema not in ('information_schema', 'performance_schema', 'mysql')
                 """,
         "schema_with_system": """
-                select
-                    table_name
+                select table_schema
+                    , table_name
                     , column_name
                     , data_type
                 from
                     information_schema.columns;
                 """,
         "schema_specified": """
-                select
-                    table_name
+                select table_schema
+                    , table_name
                     , column_name
                     , udt_name
                 from
@@ -41,19 +41,18 @@ queries = {
                 where table_schema in (%s);
                 """,
         "foreign_keys_for_table": """
-        select
-            column_name
+        select column_name
             , referenced_table_name
             , referenced_column_name
         from
             information_schema.key_column_usage
         where
             table_name = '{table}'
-            and referenced_column_name IS NOT NULL;
+            and referenced_column_name IS NOT NULL
+            and table_schema = '{table_schema}';
         """,
         "foreign_keys_for_column": """
-        select
-            column_name
+        select column_name
             , referenced_table_name
             , referenced_column_name
         from
@@ -61,18 +60,35 @@ queries = {
         where
             table_name = '{table}'
             and column_name = '{column}'
-            and referenced_column_name IS NOT NULL;
+            and referenced_column_name IS NOT NULL
+            and table_schema = '{table_schema}';
         """,
         "ref_keys_for_table": """
-            select
-                referenced_column_name
+            select referenced_column_name
                 , table_name
                 , column_name
             from
                 information_schema.key_column_usage
             where
                 referenced_table_name = '{table}'
-                and referenced_column_name IS NOT NULL;
+                and referenced_column_name IS NOT NULL
+                and table_schema = '{table_schema}';
+        """,
+        "foreign_keys_for_db": """
+            select column_name
+                , referenced_table_name
+                , referenced_column_name
+            FROM
+                information_schema.key_column_usage
+            WHERE referenced_column_name IS NOT NULL;
+        """,
+        "ref_keys_for_db": """
+            SELECT referenced_column_name,
+                   table_name,
+                   column_name
+            FROM
+                information_schema.key_column_usage
+            WHERE referenced_column_name IS NOT NULL;
         """
     }
 }


### PR DESCRIPTION
This isn't quite ready, I'll let you know when it is. I'm just creating the pull request to discuss any potential issues with this.

The reasoning is that it can take quite some time with large databases to refresh the schema. This provides the option of saving the metadata (stores with the credentials, so tied to a profile). Then, when you load from profile, you can tell it to use the cache and it will  be used for the first load. You can still manually refresh the schema if desired.

```python
db.save_metadata('my_db')
db = DB(profile='my_db', cache=True)
```

The cache is created by building dict representations of each of  the objects. This is stored in json and used to instantiate the objects if the cache is used.