### PR TITLE
Updates for mssql db's accessed via hostname\instance

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -937,7 +937,9 @@ class DB(object):
                             pwd=self.password)
                     self.cur = self.con.cursor()
             elif HAS_PYMSSQL:
-                if hasattr(self, 'port'):
+                if '\\' in self.hostname:
+                    hostname = self.hostname
+                elif hasattr(self, 'port'):
                     hostname = '{0}:{1}'.format(self.hostname, self.port)
                 else:
                     hostname = self.hostname


### PR DESCRIPTION
When accessing mssql db clusters via pymssql; port # should be ignored. 
eg
```
pymssql.connect(user=r'DOMAIN\user', password='password', host=r'hostname\instancename', database='dbname')
```