### PR TITLE
fixed missing ColumnSet import

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 import pandas as pd
 import pybars
 
-from .column import Column
+from .column import Column, ColumnSet
 from .table import Table, TableSet
 from .s3 import S3
 from .utils import profile_path, load_profile, load_from_json, dump_to_json


### PR DESCRIPTION
db.py wasn't working when I used it, including for the tutorial on the [yhat website](http://blog.yhat.com/posts/introducing-db-py.html) that uses the demo database. once i added the import for ColumnSet, it worked as expected. 