### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ See either the TODO below or [Adding a Database](./docs/adding-a-db-checklist.md
     - [x] mssql (going to be a little trickier since i don't have one)
 - [x] publish examples to nbviewer
 - [x] improve documentation and readme
-- [x] add sample database to distrobution
+- [x] add sample database to distribution
 - [x] push to Redshift
 - [ ] "joins to" for columns
     - [x] postgres

--- a/README.rst
+++ b/README.rst
@@ -549,7 +549,7 @@ TODO
 
 -  [x] publish examples to nbviewer
 -  [x] improve documentation and readme
--  [x] add sample database to distrobution
+-  [x] add sample database to distribution
 -  [x] push to Redshift
 -  [ ] "joins to" for columns
 

--- a/db/db.py
+++ b/db/db.py
@@ -82,7 +82,7 @@ class DB(object):
         Hostname your database is running on (i.e. "localhost", "10.20.1.248")
     port: int
         Port the database is running on. defaults to default port for db.
-            portgres: 5432
+            postgres: 5432
             redshift: 5439
             mysql: 3306
             sqlite: n/a
@@ -278,7 +278,7 @@ class DB(object):
 
     def load_credentials(self, profile="default"):
         """
-        Loads crentials for a given profile. Profiles are stored in
+        Loads credentials for a given profile. Profiles are stored in
         ~/.db.py_{profile_name} and are a base64 encoded JSON file. This is not
         to say this a secure way to store sensitive data, but it will probably
         stop your little sister from stealing your passwords.
@@ -979,7 +979,7 @@ class DB(object):
         else:
             bucket = conn.create_bucket(bucket_name, location=bucket_location)
         # we're going to chunk the file into pieces. according to amazon, this is
-        # much faster when it comes time to run the \COPY statment.
+        # much faster when it comes time to run the \COPY statement.
         #
         # see http://docs.aws.amazon.com/redshift/latest/dg/t_splitting-data-files.html
         sys.stderr.write("Transfering {0} to s3 in chunks".format(name))

--- a/db/s3.py
+++ b/db/s3.py
@@ -31,7 +31,7 @@ class S3(object):
 
     def load_credentials(self, profile):
         """
-        Loads crentials for a given profile. Profiles are stored in
+        Loads credentials for a given profile. Profiles are stored in
         ~/.db.py_s3_{profile_name} and are a base64 encoded JSON file. This is
         not to say this a secure way to store sensitive data, but it will
         probably stop your little sister from spinning up EC2 instances.

--- a/docs/adding-a-db-checklist.md
+++ b/docs/adding-a-db-checklist.md
@@ -53,7 +53,7 @@ all the same). Here's a checklist of what you'll need to do:
     - [ ] ref_keys_for_table
 
 Create a file called `foosql.py` and put it in the [`queries`](https://github.com/yhat/db.py/tree/master/db/queries) 
-directory. Once you've written the neccessary queries, add an import statement 
+directory. Once you've written the necessary queries, add an import statement 
 to the `db.py` file. It will look something like this:
 
 ```python


### PR DESCRIPTION
There are small typos in:
- README.md
- README.rst
- db/db.py
- db/s3.py
- docs/adding-a-db-checklist.md

Fixes:
- Should read `distribution` rather than `distrobution`.
- Should read `credentials` rather than `crentials`.
- Should read `statement` rather than `statment`.
- Should read `postgres` rather than `portgres`.
- Should read `necessary` rather than `neccessary`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md